### PR TITLE
[IMP]pabi_budget_monitor: added rpt_program_id for section and projec…

### DIFF
--- a/pabi_budget_monitor/models/account_budget.py
+++ b/pabi_budget_monitor/models/account_budget.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from openerp import models, api, _
+from openerp import models, api, _, fields
 from openerp.exceptions import ValidationError
 
 
@@ -198,3 +198,29 @@ class AccountBudget(models.Model):
                 if not res['budget_ok']:
                     return res
         return res
+
+class AccountBudgetLine(models.Model):
+    _inherit = 'account.budget.line'
+
+    @api.depends(
+        'budget_id.section_id',
+        'section_id',
+        'section_id.rpt_program_id',
+        'project_id',
+        'project_id.rpt_program_id')
+    def _compute_rpt_program_id(self):
+        for line in self:
+            if line.budget_id.chart_view == 'unit_base':
+                if line.section_id:
+                    line.rpt_program_id = line.section_id.rpt_program_id
+            elif line.budget_id.chart_view == 'project_base':
+                if line.project_id:
+                    line.rpt_program_id = line.project_id.rpt_program_id
+
+    rpt_program_id = fields.Many2one(
+        'res.program',
+        compute='_compute_rpt_program_id',
+        string='Report Program',
+        store=True,
+    )
+    

--- a/pabi_budget_monitor/models/res_org_structure.py
+++ b/pabi_budget_monitor/models/res_org_structure.py
@@ -95,6 +95,10 @@ class ResSection(models.Model):
         string='Section Monitor',
         domain=[('budget_method', '=', 'expense')],
     )
+    rpt_program_id = fields.Many2one(
+        'res.program',
+        string='Report Program',
+    )
 
 
 class ResCostcenter(models.Model):

--- a/pabi_budget_monitor/models/res_spa_structure.py
+++ b/pabi_budget_monitor/models/res_spa_structure.py
@@ -171,3 +171,7 @@ class ResProject(models.Model):
         string='Project Monitor',
         domain=[('budget_method', '=', 'expense')],
     )
+    rpt_program_id = fields.Many2one(
+        'res.program',
+        string='Report Program',
+    )

--- a/pabi_budget_monitor/report/budget_plan_report.py
+++ b/pabi_budget_monitor/report/budget_plan_report.py
@@ -13,6 +13,10 @@ class BudgetPlanReport(ChartField, models.Model):
         readonly=True,
         help="Reference to original document",
     )
+    rpt_program_id = fields.Many2one(
+        'res.program',
+        string='Report Program',
+    )
 
     def _get_dimension(self):
         # Add dimensions from chart field
@@ -22,6 +26,7 @@ class BudgetPlanReport(ChartField, models.Model):
         dimensions += ', abl.chart_view'
         # Add document reference
         dimensions += ', ab.name as document'
+        dimensions += ', abl.rpt_program_id'
         return dimensions
 
     def init(self, cr):

--- a/pabi_budget_monitor/report/budget_plan_report_view.xml
+++ b/pabi_budget_monitor/report/budget_plan_report_view.xml
@@ -43,6 +43,7 @@
                     <field name="mission_id"/>
                     <field name="tag_type_id"/>
                     <field name="tag_id"/>
+                    <field name="rpt_program_id"/>
 
                     <field name="functional_area_id"/>
                     <field name="program_group_id"/>

--- a/pabi_budget_monitor/views/account_activity_view.xml
+++ b/pabi_budget_monitor/views/account_activity_view.xml
@@ -53,6 +53,5 @@
 		    	</xpath>
             </field>
         </record>      
-    	
     </data>
 </openerp>

--- a/pabi_budget_monitor/views/res_org_structure_view.xml
+++ b/pabi_budget_monitor/views/res_org_structure_view.xml
@@ -156,6 +156,9 @@
             <field name="model">res.section</field>
             <field name="inherit_id" ref="pabi_base.view_res_section_form"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='division_id']" position="after">
+                    <field name="rpt_program_id"/>
+                </xpath>
                 <xpath expr="//notebook" position="inside">
                     <page string="Budget Monitor">
                         <separator string="Expense"/>

--- a/pabi_budget_monitor/views/res_spa_structure_view.xml
+++ b/pabi_budget_monitor/views/res_spa_structure_view.xml
@@ -304,6 +304,9 @@
             <field name="model">res.project</field>
             <field name="inherit_id" ref="pabi_base.view_res_project_form"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='project_group_id']" position="after">
+                    <field name="rpt_program_id"/>
+                </xpath>
                 <xpath expr="//notebook" position="inside">
                     <page string="Budget Monitor">
                         <separator string="Expense"/>


### PR DESCRIPTION
…t reporting ref: issues/1176

Hi Kitti,

We have tried to change or add field rpt_program_id on report view level (Budget plan / Budget consume / Budget monitor) by adding join in SQL query but did not succeed. So we have decided to go by adding funtion field on budget line object and complete report Budget plan...

Can you please check and give your feedback...

If you will be ok with function field then we will add function field on analytic line so that we can complete budget consume and budget monitor at end...

WDYT? 

Regards,
Mustufa

